### PR TITLE
Generate event loop for WSGI applications

### DIFF
--- a/vt/client.py
+++ b/vt/client.py
@@ -44,7 +44,13 @@ _USER_AGENT_FMT = '{agent}; vtpy {version}; gzip'
 
 def _make_sync(future):
   """Utility function that waits for an async call, making it sync."""
-  return asyncio.get_event_loop().run_until_complete(future)
+  try:
+    event_loop = asyncio.get_event_loop()
+  except RuntimeError:
+    # Generate an event loop if there isn't any.
+    event_loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(event_loop)
+  return event_loop.run_until_complete(future)
 
 
 def url_id(url):


### PR DESCRIPTION
Most WSGI apps doesn't have an event loop set (although they are technically running on an event loop, this is, the main process where the app is running), so we cannot convert an asynchronous task in a sync one because we don't know where to execute the tasks that are supposed to be executed in our async task.

As a quick fix and while Python frameworks for developing WSGI apps allow to use Async IO natively (seems that Django is working on it https://docs.djangoproject.com/en/3.0/topics/async/ and Tornado already have a workaround https://www.tornadoweb.org/en/stable/asyncio.html#tornado.platform.asyncio.AsyncIOMainLoop), the easiest way to avoid users struggling with the integration of vt-py and WSGI apps is to generate an event loop if the app vt-py is running on has not defined one.