### PR TITLE
remove asyncio from pypi requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ if sys.version_info < (3, 6, 0):
   raise RuntimeError('vt-py requires Python 3.6.0+')
 
 install_requires = [
-    'asyncio',
     'aiohttp',
     'pytest',
     'pytest_httpserver',


### PR DESCRIPTION
vt-py requires python 3.6+ 
asyncio from pypi is only required for python3.3 - https://pypi.org/project/asyncio/