### PR TITLE
Additional examples

### DIFF
--- a/examples/enqueue_url_scan.py
+++ b/examples/enqueue_url_scan.py
@@ -1,0 +1,69 @@
+# Copyright © 2019 The vt-py authors. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import asyncio
+import os
+import sys
+import vt
+
+
+async def get_urls_to_enqueue(queue, path, url):
+  """Finds which URLs will be enqueued to scan in VirusTotal."""
+  if url:
+    await queue.put(url)
+    return
+
+  for url in path:
+    await queue.put(url.strip())
+
+
+async def enqueue_urls(queue, apikey):
+  """Enqueues URLs in VirusTotal."""
+  async with vt.Client(apikey) as client:
+    while not queue.empty():
+      url = await queue.get()
+      await client.scan_url_async(url)
+      print(f'URL {url} enqueued for scanning.')
+      queue.task_done()
+
+
+def main():
+
+  parser = argparse.ArgumentParser(description='Enqueue URLs to be scanned.')
+
+  parser.add_argument('--apikey', required=True, help='your VirusTotal API key')
+  parser.add_argument('--workers', type=int, required=False, default=4,
+                      help='number of concurrent workers')
+  group = parser.add_mutually_exclusive_group(required=True)
+  group.add_argument('--path', type=argparse.FileType('r'),
+                      help='path to a file containing a list of URLs to scan.')
+  group.add_argument('--url', help='URL to scan.')
+  args = parser.parse_args()
+
+  loop = asyncio.get_event_loop()
+  queue = asyncio.Queue(loop=loop)
+  loop.create_task(get_urls_to_enqueue(queue, args.path, args.url))
+
+  _worker_tasks = []
+  for i in range(args.workers):
+    _worker_tasks.append(
+        loop.create_task(enqueue_urls(queue, args.apikey)))
+
+  # Wait until all worker tasks has completed.
+  loop.run_until_complete(asyncio.gather(*_worker_tasks))
+  loop.close()
+
+
+if __name__ == '__main__':
+  main()

--- a/examples/file_behaviour_feed.py
+++ b/examples/file_behaviour_feed.py
@@ -1,0 +1,78 @@
+#!/usr/local/bin/python
+# -*- coding: utf-8 -*-
+# Copyright © 2019 The vt-py authors. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+NOTICE: In order to use this program you will need an API key that has
+privileges for using the VirusTotal Feed API.
+
+Set an env-var e.g. $VT_API_KEY
+"""
+
+import argparse
+import json
+import os
+import vt
+
+
+def process_item(item):
+  """Processes a fetched item from the feed."""
+  try:
+    tags = item.tags
+  except AttributeError:
+    tags = []
+
+  try:
+    processes_created = item.processes_created
+  except AttributeError:
+    processes_created = []
+
+  if ('executes-dropped-file' in tags or
+      'powershell.exe' in '\n'.join(processes_created)):
+      print(item.id.split('_')[0])
+
+
+def main():
+
+  parser = argparse.ArgumentParser(
+      description='Get file behaviour reports from the VirusTotal feed. '
+      'Print documents dropping an executable or lauching a Powershell.')
+
+  parser.add_argument('--apikey',
+      required=True, help='your VirusTotal API key')
+
+  parser.add_argument('--cursor',
+      required=False,
+      help='cursor indicating where to start')
+
+  args = parser.parse_args()
+
+  with vt.Client(args.apikey) as client:
+    # Iterate over the file behaviour feed, one file at a time.
+    # This loop doesn't finish, when the feed is consumed it will keep waiting
+    # for more files.
+
+    try:
+      for behaviour_obj in client.feed(
+          vt.FeedType.FILE_BEHAVIOURS, cursor=args.cursor):
+        # process the behaviour_obj
+        process_item(behaviour_obj)
+    except KeyboardInterrupt:
+      print('\nKeyboard interrupt. Closing.')
+    finally:
+      client.close()
+
+
+if __name__ == '__main__':
+  main()

--- a/examples/file_provenance.py
+++ b/examples/file_provenance.py
@@ -1,0 +1,77 @@
+#!/usr/local/bin/python
+# -*- coding: utf-8 -*-
+# Copyright © 2020 The vt-py authors. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Get provenance info for a given file.
+
+This includes information signature, data from VT monitor, data from trusted
+partners and from NSLR. The file is not uploaded to VirusTotal.
+"""
+
+import argparse
+import asyncio
+import hashlib
+import vt
+import sys
+
+
+async def get_provenance_info(apikey, hash):
+  async with vt.Client(apikey) as client:
+    file_obj = await client.get_object_async(f'/files/{hash}')
+
+  return (
+      getattr(file_obj, 'monitor_info', None), getattr(file_obj, 'nsrl_info', None),
+      getattr(file_obj, 'signature_info', None), getattr(file_obj, 'tags', []),
+      getattr(file_obj, 'trusted_verdict', None))
+
+
+async def main():
+  parser = argparse.ArgumentParser(
+      description='Get provenance info for a given file.')
+
+  parser.add_argument('--apikey', required=True, help='your VirusTotal API key')
+  parser.add_argument('--path', required=True, type=argparse.FileType('rb'),
+                      help='path to the file check.')
+  args = parser.parse_args()
+
+  file_hash = hashlib.sha256(args.path.read()).hexdigest()
+
+  try:
+    monitor, nslr, signature, tags, trusted = await get_provenance_info(
+        args.apikey, file_hash)
+  except vt.error.APIError as e:
+    print(f'ERROR: {e}')
+    sys.exit(1)
+
+  if monitor:
+    print(
+        'Present in monitor collections '
+        f'of {", ".join(monitor["organizations"])}')
+
+  if nslr:
+    print(f'Present in these products: {", ".join(nslr["products"])}')
+
+  if signature:
+    print(f'{"Inv" if "invalid-signature" in tags else "V"}alid signature.')
+    print(f'Product: {signature["product"]}.')
+    print(f'Signers: {signature["signers"]}')
+
+  if trusted:
+    print(f'Trusted file by {trusted["organization"]}')
+
+
+if __name__ == '__main__':
+  loop = asyncio.get_event_loop()
+  loop.run_until_complete(main())
+  loop.close()

--- a/examples/import_yara_ruleset.py
+++ b/examples/import_yara_ruleset.py
@@ -56,12 +56,12 @@ async def upload_rules(queue, apikey, enable):
                 'enabled': enable,
                 'rules': f.read()})
 
-        try:
-          await client.post_object_async(
-              path='/intelligence/hunting_rulesets', obj=ruleset)
-          print(f'File {file_path} uploaded.')
-        except vt.error.APIError as e:
-          print(f'Error uploading {file_path}: {e}')
+      try:
+        await client.post_object_async(
+            path='/intelligence/hunting_rulesets', obj=ruleset)
+        print(f'File {file_path} uploaded.')
+      except vt.error.APIError as e:
+        print(f'Error uploading {file_path}: {e}')
 
       queue.task_done()
 

--- a/examples/search_similar_files.py
+++ b/examples/search_similar_files.py
@@ -1,0 +1,139 @@
+#!/usr/bin/python
+
+"""
+This example shows how to find similar files to a given one without uploading
+it to VirusTotal.
+
+To find similar files, this example computes both imphash and rich pe header
+hash locally, and uses both to find similar files posted in VirusTotal.
+
+This example needs the pefile python package:
+https://pypi.org/project/pefile/
+
+
+NOTE: In order to use this script you will need to have access to
+VT Intelligence or to the Premium API. Learn more about these services at:
+https://www.virustotal.com/gui/intelligence-overview
+https://developers.virustotal.com/v3.0/reference#search
+https://www.virustotal.com/learn/
+"""
+
+import argparse
+import asyncio
+import hashlib
+import pefile
+import vt
+import sys
+
+
+SEARCHES = [
+    ('have', 'behaviour_network'),
+    ('have', 'itw'),
+    ('tag', 'attachment')
+]
+
+
+def compute_hashes(path):
+  """Computes imphash and rich PE."""
+  pe = pefile.PE(path)
+
+  imphash = pe.get_imphash()
+
+  rich_data = pe.parse_rich_header()
+  # https://github.com/RichHeaderResearch/RichPE/blob/master/rich.py#L467
+  rich = hashlib.md5(rich_data['clear_data']).hexdigest() if rich_data else None
+
+  pe.close()
+
+  return imphash, rich
+
+
+def detection_rate_str(file_obj):
+  """Returns a string representing detection rate."""
+  stats = file_obj.last_analysis_stats
+  return f'{stats["malicious"]}/{sum(stats.values())}'
+
+
+async def search_files(
+      apikey, numfiles, hash_type, hash_value, search_type, search_value):
+  """Searches files on VirusTotal based on hash and a filter value.
+
+  Args:
+    apikey: str, VirusTotal API key.
+    numfiles: int, Max number of files to retrieve per search.
+    queue: asyncio queue to put results to.
+    hash_type: str, Can be either rich_pe_header_hash or imphash.
+    hash_value: str, Hash value to search for.
+    search_type: str, field to search by. Can be either tag or have.
+    search_value: str, value to search by.
+
+  Returns:
+    A set with found URLs in the files' relationships
+  """
+  search = f'{hash_type}: {hash_value} {search_type}: {search_value}'
+  urls = set()
+  async with vt.Client(apikey) as client:
+    it = client.iterator(
+        '/intelligence/search',
+        params={'query': search, 'relationships': 'itw_urls,contacted_urls'},
+        limit=numfiles)
+
+    async for file_obj in it:
+      print(
+          f'{file_obj.sha256}\t{file_obj.last_analysis_date.strftime("%Y-%m-%d")}\t'
+          f'{detection_rate_str(file_obj)}')
+
+      for rel in file_obj.relationships.values():
+        for r in rel['data']:
+          urls.add(r['context_attributes']['url'])
+
+  return urls
+
+
+async def main():
+  parser = argparse.ArgumentParser(
+      description='Search similar files to a given one without uploading it '
+                  'to VirusTotal.')
+  parser.add_argument('--apikey', required=True, help='Your VirusTotal API key')
+  parser.add_argument(
+      '-n', '--numfiles', dest='numfiles', default=20,
+      help='Number of files to search for in every search.')
+  parser.add_argument(
+      '--path', required=True,
+      help='File path to find similar files to.')
+  args = parser.parse_args()
+
+  try:
+    imphash, rich = compute_hashes(args.path)
+  except pefile.PEFormatError:
+    print('ERROR: Input file is not a PE.')
+    sys.exit(1)
+
+  loop = asyncio.get_event_loop()
+
+  tasks = []
+  print('Files having same imphash or rich PE header hash:')
+  for hash_type, hash_val in [
+        ('imphash', imphash), ('rich_pe_header_hash', rich)]:
+    for search_type, search_value in SEARCHES:
+
+      if hash_val is None:
+        continue
+
+      tasks.append(loop.create_task(
+          search_files(
+              args.apikey, args.numfiles, hash_type, hash_val,
+              search_type, search_value
+          )
+      ))
+
+  urls = await asyncio.gather(*tasks)
+  urls = set().union(*urls)
+  if urls:
+    print('\nRelated URLs:\n{}'.format('\n\t'.join(urls)))
+
+
+if __name__ == '__main__':
+  loop = asyncio.get_event_loop()
+  loop.run_until_complete(main())
+  loop.close()

--- a/examples/suspicious_network_observables.py
+++ b/examples/suspicious_network_observables.py
@@ -1,0 +1,116 @@
+#!/usr/local/bin/python
+# -*- coding: utf-8 -*-
+# Copyright © 2020 The vt-py authors. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Suspicious sightings given a list of network observables.
+
+This scripts prints suspicious sightings related to a domain or IP address.
+The scripts receives a file as input having a domain/IP address per line.
+"""
+
+import argparse
+import asyncio
+import re
+import vt
+
+
+IP_REGEX = re.compile(r'\d+\.\d+\.\d+\.\d+')
+
+
+def is_ip_address(netloc):
+  """Checks whether a given value is a IP address or not.
+
+  Args:
+    netloc: str, IP address to check.
+
+  Returns:
+    True or false
+  """
+  return IP_REGEX.match(netloc) is not None
+
+
+def get_detection_rate(stats):
+  """Get detection rate as string."""
+  return f'{stats["malicious"]}/{sum(stats.values())}'
+
+
+def print_results(results, netloc):
+  """Print results for a given netloc.
+
+  Results are only printed if there's a suspicious sighting.
+  """
+  if any(x is not None for x, _, _ in results):
+    n_spaces = 50 - len(netloc)
+    print(
+        f'{netloc}{" " * n_spaces}'
+        f'{"  ".join(f"{n} detected {t} [max:{m}]" for m, n, t in results if m)}')
+
+
+async def get_netloc_relationship(apikey, netloc, rel_type):
+  """Gets a netloc relationship and returns the highest detection rate."""
+  path = 'ip_addresses' if is_ip_address(netloc) else 'domains'
+  async with vt.Client(apikey) as client:
+    it = client.iterator(f'/{path}/{netloc}/{rel_type}', limit=20)
+    stats = [
+        get_detection_rate(f.last_analysis_stats) async for f in it
+        if f.last_analysis_stats['malicious']]
+
+    if stats:
+      text = rel_type.replace("_", " ")[:-1 if len(stats) <= 1 else None]
+      return max(stats), len(stats), text
+    else:
+      return None, 0, ''
+
+
+async def get_netloc_report_relationships(loop, apikey, netloc):
+  """Gets report and relationships for a given network location."""
+  if not netloc:
+    return
+
+  tasks = []
+  async with vt.Client(apikey) as client:
+    for rel_type in [
+        'urls', 'downloaded_files', 'communicating_files', 'referrer_files']:
+
+      tasks.append(loop.create_task(
+          get_netloc_relationship(apikey, netloc, rel_type)))
+
+  results = await asyncio.gather(*tasks, return_exceptions=True)
+  print_results(results, netloc)
+
+def main():
+  parser = argparse.ArgumentParser(
+      description='Get suspicious sightings related to a network observable.')
+
+  parser.add_argument('--apikey', required=True, help='your VirusTotal API key')
+  parser.add_argument('--path', required=True, type=argparse.FileType('r'),
+                      help='path to the file containing the domains and IPs.')
+  parser.add_argument('--limit', type=int, default=20,
+                      help='number of items to process in every search.')
+  args = parser.parse_args()
+
+  loop = asyncio.get_event_loop()
+  tasks = []
+  for n in args.path:
+    tasks.append(loop.create_task(
+        get_netloc_report_relationships(loop, args.apikey, n.strip())))
+
+  # Wait until all tasks are completed.
+  loop.run_until_complete(asyncio.gather(*tasks))
+  loop.close()
+
+
+if __name__ == '__main__':
+  main()
+

--- a/examples/suspicious_network_observables.py
+++ b/examples/suspicious_network_observables.py
@@ -89,6 +89,7 @@ async def get_netloc_report_relationships(loop, apikey, netloc):
   results = await asyncio.gather(*tasks, return_exceptions=True)
   print_results(results, netloc)
 
+
 def main():
   parser = argparse.ArgumentParser(
       description='Get suspicious sightings related to a network observable.')

--- a/examples/upload_files.py
+++ b/examples/upload_files.py
@@ -1,0 +1,73 @@
+# Copyright © 2019 The vt-py authors. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import asyncio
+import os
+import sys
+import vt
+
+
+async def get_files_to_upload(queue, path):
+  """Finds which files will be uploaded to VirusTotal."""
+  if os.path.isfile(path):
+    await queue.put(path)
+    return
+
+  with os.scandir(path) as it:
+    for entry in it:
+        if not entry.name.startswith('.') and entry.is_file():
+            await queue.put(entry.name)
+
+
+async def upload_hashes(queue, apikey):
+  """Uploads selected files to VirusTotal."""
+  async with vt.Client(apikey) as client:
+    while not queue.empty():
+      file_path = await queue.get()
+      await client.scan_file_async(file=file_path)
+      print(f'File {file_path} uploaded.')
+      queue.task_done()
+
+
+def main():
+
+  parser = argparse.ArgumentParser(description='Upload files to VirusTotal.')
+
+  parser.add_argument('--apikey', required=True, help='your VirusTotal API key')
+  parser.add_argument('--path', required=True,
+                      help='path to the file/directory to upload.')
+  parser.add_argument('--workers', type=int, required=False, default=4,
+                      help='number of concurrent workers')
+  args = parser.parse_args()
+
+  if not os.path.exists(args.path):
+    print(f'ERROR: file {args.path} not found.')
+    sys.exit(1)
+
+  loop = asyncio.get_event_loop()
+  queue = asyncio.Queue(loop=loop)
+  loop.create_task(get_files_to_upload(queue, args.path))
+
+  _worker_tasks = []
+  for i in range(args.workers):
+    _worker_tasks.append(
+        loop.create_task(upload_hashes(queue, args.apikey)))
+
+  # Wait until all worker tasks has completed.
+  loop.run_until_complete(asyncio.gather(*_worker_tasks))
+  loop.close()
+
+
+if __name__ == '__main__':
+  main()

--- a/examples/url_feed.py
+++ b/examples/url_feed.py
@@ -28,9 +28,7 @@ import vt
 
 def process_item(item):
   """Processes a fetched item from the feed."""
-  total_clean = (
-      item.last_analysis_stats['harmless'] +
-      item.last_analysis_stats['undetected'])
+  total_clean = sum(item.last_analysis_stats.values())
   num_spaces = 100 - len(item.url) if len(item.url) < 100 else 10
   print(
       f'{item.url}{" " * num_spaces}'

--- a/vt/feed.py
+++ b/vt/feed.py
@@ -37,6 +37,7 @@ class FeedType(enum.Enum):
   """Feed types."""
   FILES = 'files'
   URLS = 'urls'
+  FILE_BEHAVIOURS = 'file-behaviours'
 
 
 class Feed:


### PR DESCRIPTION
This PR adds more example scripts in the `examples/` directory:

* `enqueue_url_scan.py`: receives either a single URL or a file containing a URL per file. Enqueues all URL to be scanned.
    ```shellsession
    $ python enqueue_url_scan.py --apikey xxxxx --url https://google.com
    URL https://google.com enqueued for scanning.
    ```
* `file_behaviour_feed.py`: an example to fetch the file behaviour feed. Prints files that either drop an executable or launch a powershell.
    ```shellsession
    $ python file_behaviour_feed.py --apikey xxxx
    b4a2994ee366e996f8c072766143b8cb20910c19b09ec2164667ef35ab2539a9
    398347895787081ddbe518a3e5ec68bb9ce0e3695a2580f6a374c011fd362b01
    0fb80643ad6ddbc25fd31bbe7f22a451b38a389d01b9876705c2accc46352f66
    92384fd0cd7374975b32a1019c7c76af17881ad0a743d905d6e9e712ce93c3e7
    29df8c40e84dcad1aeb2b5ae917f3419437708c61998e5b11a7c5159c3709aeb
    1c935708b38c207211dff422edbe273b0aa8dbfe594796b75b78b4c8901d6819
    ^C
    Keyboard interrupt. Closing.
    ```
* `file_provenance`: performs a hash lookup and prints, if available, file provenance information such as trusted verdict, monitor info, NSLR info and signature.
    ```shellsession
    $ python file_provenance.py --path ~/Downloads/file.exe --apikey xxx
    Valid signature.
    Product: Microsoft SQL Server Management Studio - 18.6.
    Signers: Microsoft Corporation; Microsoft Code Signing PCA 2011; Microsoft Root Certificate Authority 2011
    Trusted file by Microsoft Corporation
    ```
* `import_yara_ruleset.py`: imports a single ruleset or all rulesets contained in a directory to VirusTotal.
    ```shellsession
    $ python import_yara_ruleset.py --apikey xxx --path /tmp/test_rules/                                                        
    Error uploading /tmp/test_rules/fail.txt: ('BadRequestError', 'Line 1: syntax error, unexpected identifier')
    File /tmp/test_rules/test.yar uploaded.
    ```
* `search_similar_files.py`: finds similar files to a given one by imphash and rich PE header hash. The original file is not uploaded to VT.
    ```shellsession
    $ python search_similar_files.py --path ~/Downloads/file.exe --apikey xxx
    Files having same imphash or rich PE header hash:
    e4a3a0d1d44d581dc1ae1580ca6bbb963839c628f7d678193dbec284bc411c92        2020-09-29      1/75
    1ac03ea42f397305d140deafa410f40f3bee106b636995a23b6dbc55f7f731ff        2020-09-29      0/75
    0d1b5b3fb97431a0725d7ca41c93777d71787796d1a90175eb0613a566c2b09a        2020-09-29      5/75
    ae41a2725de1a181368ec38a6bf8bc79e0430ad8fa95c14c5455310407828176        2020-09-29      0/75
    f56901c7e6a870faff546efa71a61ffcc140dc30d659fffc796d5202b39e1952        2020-09-29      0/75
    84603d59bc8f71997e78dbe0562ce53c93589c99ec96d29cb9b16fb836e61a81        2020-09-28      0/75
    10642b24e41e48a5b3fbbe4f4cc9bbfe07fb3f6e1056aa8d47c5ffbb1ccccd10        2020-09-28      0/75
    ffdccd7aad4e979241b3a8cf1992cd7f2178a25415052ef5d095bcaf922783b3        2020-09-25      0/75

    Related URLs:
        http://www.cityofangelsmagazine.com/images/logos.gif?2f48a8a=396645456
        http://museum.php.net/win32/php-4.3.9-installer.exe
        http://sagocugenc.sa.funpic.de/images/logos.gif?63e27a3=942630075
        http://bionet.com.tr/main.gif?f8cc900=1304423680
        http://www.finson.com/upgrade/Cd0773/Upgrade.exe
        http://www.dialsl.es/uploads/descargas/ParcheCodex240920.exe
        http://museum.php.net/win32/php-4.1.1-installer.exe
        http://museum.php.net/win32/php-4.4.2-installer.exe
    ```
* `suspicious_network_observables.py`: searches for suspicious related items to domains and IP addresses.
    ```shellsession
    $ python suspicious_network_observables.py --apikey xxx --path test.txt
    unicusadvisors.com                                10 detected urls [max:6/79]  5 detected downloaded files [max:47/75]  20 detected communicating files [max:38/75]
    8.8.8.8                                           9 detected urls [max:8/79]  11 detected downloaded files [max:61/76]  20 detected communicating files [max:6/75]  20 detected referrer files [max:55/72]
    google.com                                        3 detected urls [max:2/65]  1 detected downloaded file [max:1/76]  20 detected communicating files [max:62/75]  20 detected referrer files [max:6/73]
    ```
* `upload_files.py`: uploads a single file or all files under a given directory to VirusTotal.
    ```shelsession
    $ python upload_files.py --apikey xxx --path /tmp/test
    File /tmp/test/void.txt uploaded.
    ```

Also, both `intelligence_search_to_network_infrastructure.py` and `url_feed.py` scripts have been improved.