### PR TITLE
Add support for next in iterator object

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -250,8 +250,8 @@ def test_iterator(httpserver):
   })
 
   with new_client(httpserver) as client:
-    it = client.iterator('/dummy_collection/{}', 'foo')
-    for i, obj in enumerate(it):
+    it = client.iterator('/dummy_collection/foo', limit=10)
+    for i, _ in enumerate(it):
       assert 0 == i
 
 

--- a/tests/test_iterator.py
+++ b/tests/test_iterator.py
@@ -11,11 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import bz2
-import datetime
-import io
-import json
-
 import pytest
 import pytest_httpserver
 

--- a/tests/test_iterator.py
+++ b/tests/test_iterator.py
@@ -59,11 +59,12 @@ def test_next(httpserver, iterator_response):
   with new_client(httpserver) as client:
     it = client.iterator('/dummy_collection/foo', limit=10)
     assert next(it).id == 'dummy_id_1'
+    assert next(it).id == 'dummy_id_2'
 
     # iteration must start right where the next stayed
     last = None
     for i, obj in enumerate(it):
-      assert obj.id == f'dummy_id_{i+2}'
+      assert obj.id == f'dummy_id_{i+3}'
       last = obj
 
     assert last.id == 'dummy_id_4'
@@ -81,18 +82,19 @@ def test_next(httpserver, iterator_response):
 def test_next_limit(httpserver, iterator_response):
   """Tests iterator's next with a limit smaller than the total of elements."""
   with new_client(httpserver) as client:
-    it = client.iterator('/dummy_collection/foo', limit=2)
+    it = client.iterator('/dummy_collection/foo', limit=3)
     assert next(it).id == 'dummy_id_1'
+    assert next(it).id == 'dummy_id_2'
 
     # iteration must start right where the next stayed
     last = None
     for i, obj in enumerate(it):
-      assert obj.id == f'dummy_id_{i+2}'
+      assert obj.id == f'dummy_id_{i+3}'
       last = obj
 
     # last element must be the one marked by the limit
-    assert last.id == 'dummy_id_2'
-    assert it._count == 2
+    assert last.id == 'dummy_id_3'
+    assert it._count == 3
 
     with pytest.raises(StopIteration):
       # there shouldn't be more available elements after the for loop

--- a/tests/test_iterator.py
+++ b/tests/test_iterator.py
@@ -1,0 +1,128 @@
+# Copyright 2020 The vt-py authors. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import bz2
+import datetime
+import io
+import json
+
+import pytest
+import pytest_httpserver
+
+from vt import Client
+
+
+def new_client(httpserver):
+  return Client('dummy_api_key',
+      host='http://' + httpserver.host + ':' + str(httpserver.port))
+
+
+@pytest.fixture
+def iterator_response(httpserver):
+  httpserver.expect_request(
+      '/api/v3/dummy_collection/foo',
+      method='GET',
+      headers={'X-Apikey': 'dummy_api_key'}
+  ).respond_with_json({
+      'data': [{
+          'id': 'dummy_id_1',
+          'type': 'dummy_type',
+          'attributes': {'order': 0}
+          }, {
+          'id': 'dummy_id_2',
+          'type': 'dummy_type',
+          'attributes': {'order': 0}
+          }, {
+          'id': 'dummy_id_3',
+          'type': 'dummy_type',
+          'attributes': {'order': 0}
+          }, {
+          'id': 'dummy_id_4',
+          'type': 'dummy_type',
+          'attributes': {'order': 0}
+          }]
+  })
+
+
+def test_next(httpserver, iterator_response):
+  """Tests iterator's next with a limit higher than the total of elements."""
+  with new_client(httpserver) as client:
+    it = client.iterator('/dummy_collection/foo', limit=10)
+    assert next(it).id == 'dummy_id_1'
+
+    # iteration must start right where the next stayed
+    last = None
+    for i, obj in enumerate(it):
+      assert obj.id == f'dummy_id_{i+2}'
+      last = obj
+
+    assert last.id == 'dummy_id_4'
+    assert it._count == 4
+
+    with pytest.raises(StopIteration):
+      # there shouldn't be more available elements after the for loop
+      next(it)
+
+    # trying to iterate over next element must not work
+    for obj in it:
+      pytest.fail('Iteration should already be finished')
+
+
+def test_next_limit(httpserver, iterator_response):
+  """Tests iterator's next with a limit smaller than the total of elements."""
+  with new_client(httpserver) as client:
+    it = client.iterator('/dummy_collection/foo', limit=2)
+    assert next(it).id == 'dummy_id_1'
+
+    # iteration must start right where the next stayed
+    last = None
+    for i, obj in enumerate(it):
+      assert obj.id == f'dummy_id_{i+2}'
+      last = obj
+
+    # last element must be the one marked by the limit
+    assert last.id == 'dummy_id_2'
+    assert it._count == 2
+
+    with pytest.raises(StopIteration):
+      # there shouldn't be more available elements after the for loop
+      next(it)
+
+    # trying to iterate over next elements must not work
+    for obj in it:
+      pytest.fail('Iteration should already be finished')
+
+@pytest.mark.asyncio
+async def test_anext(httpserver, iterator_response):
+  """Tests iterator's async next."""
+  async with new_client(httpserver) as client:
+    it = client.iterator('/dummy_collection/foo', limit=10)
+    assert (await it.__anext__()).id == 'dummy_id_1'
+
+    # iteration must start right where the next stayed
+    last, i = None, 0
+    async for obj in it:
+      assert obj.id == f'dummy_id_{i+2}'
+      last = obj
+      i += 1
+
+    assert last.id == 'dummy_id_4'
+    assert it._count == 4
+
+    with pytest.raises(StopAsyncIteration):
+      # there shouldn't be more available elements after the for loop
+      await it.__anext__()
+
+    # trying to iterate over next element must not work
+    async for obj in it:
+      pytest.fail('Iteration should already be finished')

--- a/vt/iterator.py
+++ b/vt/iterator.py
@@ -143,7 +143,7 @@ class Iterator:
   def __next__(self):
     if not self._items and self._count == 0:  # next is called before iter
       self._items, self._server_cursor = self._get_batch()
-    else:  # next is called after iter
+    elif (not self._items and self._count > 0) or self._count >= self._limit:
       raise StopIteration()
     item = self._items.pop(0)
     self._count += 1
@@ -153,7 +153,7 @@ class Iterator:
   async def __anext__(self):
     if not self._items and self._count == 0:  # next is called before iter
       self._items, self._server_cursor = await self._get_batch_async()
-    else:  # next is called after iter
+    elif (not self._items and self._count > 0) or self._count >= self._limit:
       raise StopAsyncIteration()
     item = self._items.pop(0)
     self._count += 1

--- a/vt/iterator.py
+++ b/vt/iterator.py
@@ -115,7 +115,8 @@ class Iterator:
     return self._parse_response(json_resp, batch_cursor)
 
   def __iter__(self):
-    self._items, self._server_cursor = self._get_batch()
+    if not self._items and self._count == 0:  # iter called before next
+      self._items, self._server_cursor = self._get_batch()
     while (self._items or self._server_cursor) and self._count < self._limit:
       if len(self._items) == 0:
         self._items, self._server_cursor = self._get_batch()
@@ -127,7 +128,8 @@ class Iterator:
         yield Object.from_dict(item)
 
   async def __aiter__(self):
-    self._items, self._server_cursor = await self._get_batch_async()
+    if not self._items and self._count == 0: # iter called before next
+      self._items, self._server_cursor = await self._get_batch_async()
     while (self._items or self._server_cursor) and self._count < self._limit:
       if len(self._items) == 0:
         self._items, self._server_cursor = await self._get_batch_async()
@@ -137,6 +139,26 @@ class Iterator:
         self._count += 1
         self._batch_cursor += 1
         yield Object.from_dict(item)
+
+  def __next__(self):
+    if not self._items and self._count == 0:  # next is called before iter
+      self._items, self._server_cursor = self._get_batch()
+    else:  # next is called after iter
+      raise StopIteration()
+    item = self._items.pop(0)
+    self._count += 1
+    self._batch_cursor += 1
+    return Object.from_dict(item)
+
+  async def __anext__(self):
+    if not self._items and self._count == 0:  # next is called before iter
+      self._items, self._server_cursor = await self._get_batch_async()
+    else:  # next is called after iter
+      raise StopAsyncIteration()
+    item = self._items.pop(0)
+    self._count += 1
+    self._batch_cursor += 1
+    return Object.from_dict(item)
 
   @property
   def cursor(self):


### PR DESCRIPTION
closes #24 

```python
Python 3.7.5 (default, Nov  1 2019, 02:16:32) 
[Clang 11.0.0 (clang-1100.0.33.8)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import vt
>>> client = vt.Client('xxxx')
>>> it = client.iterator('/domains/google.com/downloaded_files', limit=3)
>>> next(it)
<vt.object.Object object at 0x1056fc5d0>
>>> next(it)
<vt.object.Object object at 0x1056fced0>
>>> next(it)
<vt.object.Object object at 0x1056f4d10>
>>> next(it)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/mgmacias/Documents/GitHub/vt-py/vt/iterator.py", line 147, in __next__
    raise StopIteration()
StopIteration
```