### PR TITLE
Add __str__ and __repr__ to the Object class

### DIFF
--- a/vt/object.py
+++ b/vt/object.py
@@ -147,6 +147,12 @@ class Object(object):
       self.__on_attr_change(attr)
     super().__setattr__(attr, value)
 
+  def __repr__(self):
+    return f'<vt.object.Object {str(self)}>'
+
+  def __str__(self):
+    return f'{self.type} {self.id}'
+
   @property
   def id(self):
     return self._id


### PR DESCRIPTION
Before:

```python
>>> import vt
>>> client = vt.Client('xxx')
>>> it = client.iterator('/domains/google.com/downloaded_files', limit=3)
>>> list(it)
[<vt.object.Object object at 0x10ae53fd0>, <vt.object.Object object at 0x10ae53f90>, <vt.object.Object object at 0x10aa0f250>]
```

After:

```python
>>> import vt
>>> client = vt.Client('xxx')
>>> it = client.iterator('/domains/google.com/downloaded_files', limit=3)
>>> list(it)
[<vt.object.Object file 45bf8866af1dfdbfc4177d3807df43221e87bd3037d6681b4bd3d8b402376f9e>, <vt.object.Object file ec7ee9eb45069d5716658a384b9c6738543ae20c60004dfbf7c6abcffa38a134>, <vt.object.Object file 10a01be40c332fffbbad2df799c98d6a45af24cd78a10c264f37c51b7fc50869>]
```

Having both `__str__` and `__repr__` improves usability and readability :)