### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ python:
 - '3.7'
 install:
 - python setup.py install
+- pip install codespell
 script:
+- codespell --ignore-words-list="nd" --skip="*.css,*.js,*.svg"
 - python setup.py test
 deploy:
   provider: pypi

--- a/docs/_modules/vt/client.html
+++ b/docs/_modules/vt/client.html
@@ -323,7 +323,7 @@
 <span class="sd">  &quot;&quot;&quot;</span>
 
   <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">apikey</span><span class="p">,</span> <span class="n">agent</span><span class="o">=</span><span class="s2">&quot;unknown&quot;</span><span class="p">,</span> <span class="n">host</span><span class="o">=</span><span class="kc">None</span><span class="p">):</span>
-    <span class="sd">&quot;&quot;&quot;Intialize the client with the provided API key.&quot;&quot;&quot;</span>
+    <span class="sd">&quot;&quot;&quot;Initialize the client with the provided API key.&quot;&quot;&quot;</span>
 
     <span class="k">if</span> <span class="ow">not</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">apikey</span><span class="p">,</span> <span class="nb">str</span><span class="p">):</span>
       <span class="k">raise</span> <span class="ne">ValueError</span><span class="p">(</span><span class="s1">&#39;API key must be a string&#39;</span><span class="p">)</span>
@@ -419,7 +419,7 @@
 <div class="viewcode-block" id="Client.download_file"><a class="viewcode-back" href="../../api/client.html#vt.Client.download_file">[docs]</a>  <span class="k">def</span> <span class="nf">download_file</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="nb">hash</span><span class="p">,</span> <span class="n">file</span><span class="p">):</span>
     <span class="sd">&quot;&quot;&quot;Downloads a file given its hash (SHA-256, SHA-1 or MD5).</span>
 
-<span class="sd">    The file indentified by the hash will be written to the provided file</span>
+<span class="sd">    The file identified by the hash will be written to the provided file</span>
 <span class="sd">    object. The file object must be opened in write binary mode (&#39;wb&#39;).</span>
 
 <span class="sd">    :param hash: File hash.</span>
@@ -512,7 +512,7 @@
     <span class="sd">&quot;&quot;&quot;Given a :class:`ClientResponse` returns a :class:`APIError`</span>
 
 <span class="sd">    This function checks if the response from the VirusTotal backend was an</span>
-<span class="sd">    error and returns the appropiate :class:`APIError` or None if no error</span>
+<span class="sd">    error and returns the appropriate :class:`APIError` or None if no error</span>
 <span class="sd">    occurred.</span>
 
 <span class="sd">    :param response: A :class:`ClientResponse` instance.</span>

--- a/docs/_modules/vt/feed.html
+++ b/docs/_modules/vt/feed.html
@@ -272,7 +272,7 @@
         <span class="k">break</span>
       <span class="k">except</span> <span class="n">APIError</span> <span class="k">as</span> <span class="n">error</span><span class="p">:</span>
         <span class="c1"># The only acceptable error here is NotFoundError, if such an error</span>
-        <span class="c1"># occurrs we try to get the next batch.</span>
+        <span class="c1"># occurs we try to get the next batch.</span>
         <span class="k">if</span> <span class="n">error</span><span class="o">.</span><span class="n">code</span> <span class="o">!=</span> <span class="s1">&#39;NotFoundError&#39;</span><span class="p">:</span>
           <span class="k">raise</span> <span class="n">error</span>
         <span class="n">missing_batches</span> <span class="o">+=</span> <span class="mi">1</span>

--- a/docs/_sources/overview.rst.txt
+++ b/docs/_sources/overview.rst.txt
@@ -14,7 +14,7 @@ as you will see very generic APIs like :meth:`vt.Client.get`, :meth:`vt.Client.p
 and so on. In fact, you will find yourself relying on the REST API documentation
 in order to find the right endpoint where to send a request to, or learn about
 the attributes exported by some object. This has been a deliberate decision.
-We wanted `vt-py` to be as lightweight and generic as posible, so that changes
+We wanted `vt-py` to be as lightweight and generic as possible, so that changes
 in the REST API don't always require a new version of this client library, but
 at the same time offering the right abstractions so that you don't need to deal
 with details like setting HTTP headers, serializing and deserializing JSON, etc.

--- a/docs/_sources/quickstart.rst.txt
+++ b/docs/_sources/quickstart.rst.txt
@@ -89,7 +89,7 @@ Scan a file
 
 Before scanning a file is highly recommended that you look up for it as
 described in `Get information about a file <#get-information-about-a-file>`_.
-If the file already exists and the lastest analysis is fresh enough, you can
+If the file already exists and the latest analysis is fresh enough, you can
 use that instead of scanning the file again. If not, you can scan it with:
 
 >>> with open("/path/to/file", "rb") as f:

--- a/docs/api/client.html
+++ b/docs/api/client.html
@@ -217,7 +217,7 @@ placeholders used in path.</p></li>
 <dt id="vt.Client.download_file">
 <code class="sig-name descname">download_file</code><span class="sig-paren">(</span><em class="sig-param">hash</em>, <em class="sig-param">file</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/vt/client.html#Client.download_file"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#vt.Client.download_file" title="Permalink to this definition">¶</a></dt>
 <dd><p>Downloads a file given its hash (SHA-256, SHA-1 or MD5).</p>
-<p>The file indentified by the hash will be written to the provided file
+<p>The file identified by the hash will be written to the provided file
 object. The file object must be opened in write binary mode (‘wb’).</p>
 <dl class="field-list simple">
 <dt class="field-odd">Parameters</dt>
@@ -322,7 +322,7 @@ called.</p>
 <em class="property">async </em><code class="sig-name descname">get_error_async</code><span class="sig-paren">(</span><em class="sig-param">response</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/vt/client.html#Client.get_error_async"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#vt.Client.get_error_async" title="Permalink to this definition">¶</a></dt>
 <dd><p>Given a <a class="reference internal" href="#vt.ClientResponse" title="vt.ClientResponse"><code class="xref py py-class docutils literal notranslate"><span class="pre">ClientResponse</span></code></a> returns a <a class="reference internal" href="#vt.APIError" title="vt.APIError"><code class="xref py py-class docutils literal notranslate"><span class="pre">APIError</span></code></a></p>
 <p>This function checks if the response from the VirusTotal backend was an
-error and returns the appropiate <a class="reference internal" href="#vt.APIError" title="vt.APIError"><code class="xref py py-class docutils literal notranslate"><span class="pre">APIError</span></code></a> or None if no error
+error and returns the appropriate <a class="reference internal" href="#vt.APIError" title="vt.APIError"><code class="xref py py-class docutils literal notranslate"><span class="pre">APIError</span></code></a> or None if no error
 occurred.</p>
 <dl class="field-list simple">
 <dt class="field-odd">Parameters</dt>
@@ -516,7 +516,7 @@ a collection, like /intelligence/hunting_rulesets.</p>
 <li><p><strong>path</strong> (<em>str</em>) – Path to API endpoint.</p></li>
 <li><p><strong>path_args</strong> – A variable number of arguments that are put into any
 placeholders used in path.</p></li>
-<li><p><strong>obj</strong> (<code class="xref py py-class docutils literal notranslate"><span class="pre">Object</span></code>) – Instance <code class="xref py py-class docutils literal notranslate"><span class="pre">Object</span></code> whith the type expected by the API
+<li><p><strong>obj</strong> (<code class="xref py py-class docutils literal notranslate"><span class="pre">Object</span></code>) – Instance <code class="xref py py-class docutils literal notranslate"><span class="pre">Object</span></code> with the type expected by the API
 endpoint.</p></li>
 </ul>
 </dd>

--- a/docs/overview.html
+++ b/docs/overview.html
@@ -163,7 +163,7 @@ as you will see very generic APIs like <a class="reference internal" href="api/c
 and so on. In fact, you will find yourself relying on the REST API documentation
 in order to find the right endpoint where to send a request to, or learn about
 the attributes exported by some object. This has been a deliberate decision.
-We wanted <cite>vt-py</cite> to be as lightweight and generic as posible, so that changes
+We wanted <cite>vt-py</cite> to be as lightweight and generic as possible, so that changes
 in the REST API don’t always require a new version of this client library, but
 at the same time offering the right abstractions so that you don’t need to deal
 with details like setting HTTP headers, serializing and deserializing JSON, etc.</p>

--- a/docs/quickstart.html
+++ b/docs/quickstart.html
@@ -247,7 +247,7 @@ function. This other code is equivalent:</p>
 <h2>Scan a file<a class="headerlink" href="#scan-a-file" title="Permalink to this headline">¶</a></h2>
 <p>Before scanning a file is highly recommended that you look up for it as
 described in <a class="reference external" href="#get-information-about-a-file">Get information about a file</a>.
-If the file already exists and the lastest analysis is fresh enough, you can
+If the file already exists and the latest analysis is fresh enough, you can
 use that instead of scanning the file again. If not, you can scan it with:</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="k">with</span> <span class="nb">open</span><span class="p">(</span><span class="s2">&quot;/path/to/file&quot;</span><span class="p">,</span> <span class="s2">&quot;rb&quot;</span><span class="p">)</span> <span class="k">as</span> <span class="n">f</span><span class="p">:</span>
 <span class="gp">&gt;&gt;&gt; </span>  <span class="n">analysis</span> <span class="o">=</span> <span class="n">client</span><span class="o">.</span><span class="n">scan_file</span><span class="p">(</span><span class="n">f</span><span class="p">)</span>

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -14,7 +14,7 @@ as you will see very generic APIs like :meth:`vt.Client.get`, :meth:`vt.Client.p
 and so on. In fact, you will find yourself relying on the REST API documentation
 in order to find the right endpoint where to send a request to, or learn about
 the attributes exported by some object. This has been a deliberate decision.
-We wanted `vt-py` to be as lightweight and generic as posible, so that changes
+We wanted `vt-py` to be as lightweight and generic as possible, so that changes
 in the REST API don't always require a new version of this client library, but
 at the same time offering the right abstractions so that you don't need to deal
 with details like setting HTTP headers, serializing and deserializing JSON, etc.

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -89,7 +89,7 @@ Scan a file
 
 Before scanning a file is highly recommended that you look up for it as
 described in `Get information about a file <#get-information-about-a-file>`_.
-If the file already exists and the lastest analysis is fresh enough, you can
+If the file already exists and the latest analysis is fresh enough, you can
 use that instead of scanning the file again. If not, you can scan it with:
 
 >>> with open("/path/to/file", "rb") as f:

--- a/examples/file_behaviour_feed.py
+++ b/examples/file_behaviour_feed.py
@@ -46,7 +46,7 @@ def main():
 
   parser = argparse.ArgumentParser(
       description='Get file behaviour reports from the VirusTotal feed. '
-      'Print documents dropping an executable or lauching a Powershell.')
+      'Print documents dropping an executable or launching a Powershell.')
 
   parser.add_argument('--apikey',
       required=True, help='your VirusTotal API key')

--- a/vt/client.py
+++ b/vt/client.py
@@ -195,7 +195,7 @@ class Client:
 
   def __init__(self, apikey, agent="unknown", host=None, trust_env=False,
                timeout=300):
-    """Intialize the client with the provided API key."""
+    """Initialize the client with the provided API key."""
 
     if not isinstance(apikey, str):
       raise ValueError('API key must be a string')
@@ -295,7 +295,7 @@ class Client:
   def download_file(self, hash, file):
     """Downloads a file given its hash (SHA-256, SHA-1 or MD5).
 
-    The file indentified by the hash will be written to the provided file
+    The file identified by the hash will be written to the provided file
     object. The file object must be opened in write binary mode ('wb').
 
     :param hash: File hash.
@@ -388,7 +388,7 @@ class Client:
     """Given a :class:`ClientResponse` returns a :class:`APIError`
 
     This function checks if the response from the VirusTotal backend was an
-    error and returns the appropiate :class:`APIError` or None if no error
+    error and returns the appropriate :class:`APIError` or None if no error
     occurred.
 
     :param response: A :class:`ClientResponse` instance.
@@ -531,7 +531,7 @@ class Client:
     :param path: Path to API endpoint.
     :param path_args: A variable number of arguments that are put into any
       placeholders used in path.
-    :param obj: Instance :class:`Object` whith the type expected by the API
+    :param obj: Instance :class:`Object` with the type expected by the API
       endpoint.
     :type path: str
     :type obj: :class:`Object`

--- a/vt/feed.py
+++ b/vt/feed.py
@@ -123,7 +123,7 @@ class Feed:
         break
       except APIError as error:
         # The only acceptable error here is NotFoundError, if such an error
-        # occurrs we try to get the next batch.
+        # occurs we try to get the next batch.
         if error.code != 'NotFoundError':
           raise error
         missing_batches += 1


### PR DESCRIPTION
This PR was created via [codespell --ignore-words-list="nd" --skip="\*.css,\*.js,*.svg" -w](https://github.com/codespell-project/codespell)