### PR TITLE
Revert "Temporary manual trigger for publishing action (#73)"

### DIFF
--- a/.github/workflows/publishing.yaml
+++ b/.github/workflows/publishing.yaml
@@ -1,6 +1,8 @@
 name: Publishing package to pypi
 
-on: workflow_dispatch
+on:
+  release:
+    types: [published]
 
 jobs:
   deploy:


### PR DESCRIPTION
This reverts commit 50408817983236c901715f20338c3abbafb86640.

Already tested package publishing at https://github.com/VirusTotal/vt-py/actions/runs/1185385961.