### PR TITLE
Call `close` when `vt.Client` is destroyed.

### DIFF
--- a/vt/client.py
+++ b/vt/client.py
@@ -260,6 +260,9 @@ class Client:
   def __exit__(self, item_type, value, traceback):
     self.close()
 
+  def __del__(self):
+    self.close()
+
   def _extract_data_from_json(self, json_response):
     if not 'data' in json_response:
       raise ValueError('response does not returns a data field')

--- a/vt/version.py
+++ b/vt/version.py
@@ -1,3 +1,3 @@
 """Defines VT release version."""
 
-__version__ = '0.16.0'
+__version__ = '0.17.0'


### PR DESCRIPTION
This prevents leaking aiohttp.ClientSession objects that complain about unclosed event loops when the program exits.