### PR TITLE
Move initialization of private attribs to before check for API key

### DIFF
--- a/vt/client.py
+++ b/vt/client.py
@@ -203,12 +203,6 @@ class Client:
                timeout=300, proxy=None, headers=None, verify_ssl=True):
     """Initialize the client with the provided API key."""
 
-    if not isinstance(apikey, str):
-      raise ValueError('API key must be a string')
-
-    if not apikey:
-      raise ValueError('API key can not be an empty string')
-
     self._host = host or _API_HOST
     self._apikey = apikey
     self._agent = agent
@@ -218,6 +212,12 @@ class Client:
     self._proxy = proxy
     self._user_headers = headers
     self._verify_ssl = verify_ssl
+
+    if not isinstance(apikey, str):
+      raise ValueError('API key must be a string')
+
+    if not apikey:
+      raise ValueError('API key can not be an empty string')
 
   def _full_url(self, path, *args):
     try:


### PR DESCRIPTION
If the vt client is initialized without providing an API key it will throw a ValueError (expected).
However, I'm seeing an ignored exception from asyncio event loop as shown here:
```python
Exception ignored in: <function Client.__del__ at 0x000002ACD5077670>
Traceback (most recent call last):
  File "f:\anaconda\envs\msticpy\lib\site-packages\vt\client.py", line 263, in __del__
    self.close()
  File "f:\anaconda\envs\msticpy\lib\site-packages\vt\client.py", line 295, in close
    return make_sync(self.close_async())
  File "f:\anaconda\envs\msticpy\lib\site-packages\vt\utils.py", line 27, in make_sync
    return event_loop.run_until_complete(future)
  File "f:\anaconda\envs\msticpy\lib\site-packages\nest_asyncio.py", line 70, in run_until_complete
    return f.result()
  File "f:\anaconda\envs\msticpy\lib\asyncio\futures.py", line 201, in result
    raise self._exception
  File "f:\anaconda\envs\msticpy\lib\asyncio\tasks.py", line 256, in __step
    result = coro.send(None)
  File "f:\anaconda\envs\msticpy\lib\site-packages\vt\client.py", line 285, in close_async
    if self._session:
AttributeError: 'Client' object has no attribute '_session'
```

This isn't surfaced as an exception but is still output to std_out in the notebook. My assumption is that task is being cancelled and the partially-initialized client instance is getting deleted. The `self.__del__()` method is called, which in turn calls, `self.close()` and `self.close_async()`.
```python
  async def close_async(self):
    """Like :func:`close` but returns a coroutine."""
    if self._session:
      await self._session.close()
      self._session = None
```
Since the ValueError is thrown in __init__ before self._session is initialized to None, this results in an AttributeError in the task.

Exactly why this is happening is a bit mysterious to me - but switching __init__ statement ordering so that attribs are initialized before the API key checks, makes this disappear. Seems that it is an innoccuous change that shouldn't have any other weird side effects.