### PR TITLE
fix(object): Load a pickled vt object

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -73,8 +73,10 @@ def test_object_date_attrs():
 
 def test_object_pickle():
   obj = Object("dummy")
-  obj.whatever = {'1': '2'}
-  pickle.loads(pickle.dumps(obj))
+  obj.whatever = {"1": "2"}
+  new = pickle.loads(pickle.dumps(obj))
+  assert new.whatever == obj.whatever
+  assert new.to_dict() == obj.to_dict()
 
 
 def test_object_to_dict():

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -16,6 +16,7 @@
 import datetime
 import io
 import json
+import pickle
 
 import pytest
 from vt import APIError
@@ -68,6 +69,12 @@ def test_object_date_attrs():
   obj.foo_date = 0
 
   assert obj.foo_date == datetime.datetime(1970, 1, 1, 0, 0, 0)
+
+
+def test_object_pickle():
+  obj = Object("dummy")
+  obj.whatever = {'1': '2'}
+  pickle.loads(pickle.dumps(obj))
 
 
 def test_object_to_dict():

--- a/vt/object.py
+++ b/vt/object.py
@@ -13,6 +13,7 @@
 
 """Defines a VT object and other helper classes."""
 
+import collections
 import datetime
 import functools
 import re
@@ -21,7 +22,7 @@ import typing
 __all__ = ["Object"]
 
 
-class WhistleBlowerDict(dict):
+class WhistleBlowerDict(collections.UserDict):
   """Helper class for detecting changes in a dictionary.
 
   This class wraps a standard Python dictionary and calls the provided callback
@@ -141,7 +142,7 @@ class Object:
     self._modified_data = {}
     self._error = None
 
-  def __on_attr_change(self, attr: str) -> None:
+  def _on_attr_change(self, attr: str) -> None:
     if hasattr(self, "_modified_attrs"):
       self._modified_attrs.append(attr)
 
@@ -156,12 +157,12 @@ class Object:
   def __setattr__(self, attr: str, value: typing.Any) -> None:
     if isinstance(value, dict):
       value = WhistleBlowerDict(
-          value, functools.partial(self.__on_attr_change, attr)
+          value, functools.partial(self._on_attr_change, attr)
       )
     elif isinstance(value, datetime.datetime):
       value = int(datetime.datetime.timestamp(value))
     if attr not in self.__dict__ or value != self.__dict__[attr]:
-      self.__on_attr_change(attr)
+      self._on_attr_change(attr)
     super().__setattr__(attr, value)
 
   def __repr__(self) -> str:


### PR DESCRIPTION
fixes #172

This PR changes the class `WhistleBlowerDict` to inherit from a `UserDict` instead of inheriting directly from `dict`. This is a best practice and resolves the issue when pickling the object.