### PR TITLE
fix(object): Object of type WhistleBlowerDict is not JSON serializable

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -176,7 +176,7 @@ def test_get_object(httpserver):
 
 def test_patch_object(httpserver):
   obj = Object("dummy_type", "dummy_id", {"foo": 1, "bar": 2})
-  obj._context_attributes = {'a': 'b'}
+  obj._context_attributes = {"a": "b"}  # pylint: disable=protected-access
   obj.foo = 2
 
   httpserver.expect_request(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -176,6 +176,7 @@ def test_get_object(httpserver):
 
 def test_patch_object(httpserver):
   obj = Object("dummy_type", "dummy_id", {"foo": 1, "bar": 2})
+  obj._context_attributes = {'a': 'b'}
   obj.foo = 2
 
   httpserver.expect_request(
@@ -191,6 +192,7 @@ def test_patch_object(httpserver):
               "attributes": {
                   "foo": 2,
               },
+              "context_attributes": {"a": "b"}
           }
       }
   )

--- a/vt/client.py
+++ b/vt/client.py
@@ -15,6 +15,7 @@
 
 import asyncio
 import base64
+import functools
 import io
 import json
 import typing
@@ -25,6 +26,7 @@ from .error import APIError
 from .feed import Feed, FeedType
 from .iterator import Iterator
 from .object import Object
+from .object import UserDictJsonEncoder
 from .utils import make_sync
 from .version import __version__
 
@@ -267,6 +269,7 @@ class Client:
           headers=headers,
           trust_env=self._trust_env,
           timeout=aiohttp.ClientTimeout(total=self._timeout),
+          json_serialize=functools.partial(json.dumps, cls=UserDictJsonEncoder)
       )
     return self._session
 

--- a/vt/object.py
+++ b/vt/object.py
@@ -16,6 +16,7 @@
 import collections
 import datetime
 import functools
+import json
 import re
 import typing
 
@@ -49,6 +50,15 @@ class WhistleBlowerDict(collections.UserDict):
   def __delitem__(self, item):
     self._on_change_callback()
     super().__delitem__(item)
+
+
+class UserDictJsonEncoder(json.JSONEncoder):
+  """Custom json encoder for UserDict objects."""
+
+  def default(self, o):
+    if isinstance(o, collections.UserDict):
+      return o.data
+    return super().default(o)
 
 
 class Object:


### PR DESCRIPTION
closes #176 

The `json.dumps` function only accepts native types by default (i.e. `list`, `dict`, `str`, `int`, etc etc) but it is not prepared to parse user custom types such as `UserDict`. To parse custom types, it is required to extend the default `JsonEncoder` class available at the `json` module. This PR does this, and integrates it into the aiohttp's client session.

This PR also updates the tests to support this use case since the problem was not the dictionary representing the object itself but the `context_attributes` dictionary inside the object which is an instance of the `WhistleBlowerDict` class.