### PR TITLE
Fixes Object of type WhistleBlowerDict is not JSON serializable

### DIFF
--- a/examples/create_collection.py
+++ b/examples/create_collection.py
@@ -15,8 +15,8 @@
 
 import argparse
 import io
-import json
 import vt
+from pprint import pprint
 
 
 def create_collection(client, name, description, file):
@@ -66,7 +66,7 @@ def main():
   collection_obj = create_collection(client, args.name, args.description, iocs)
 
   client.close()
-  print(json.dumps(collection_obj.to_dict(), indent=2))
+  pprint(collection_obj.to_dict())
 
   print(f"Link:\n{generate_ui_link(collection_obj.id)}")
 

--- a/examples/create_reference.py
+++ b/examples/create_reference.py
@@ -170,7 +170,7 @@ def main():
 
   client.close()
   if reference_obj:
-    print(pprint(reference_obj.to_dict()))
+    pprint(reference_obj.to_dict())
 
 
 if __name__ == "__main__":

--- a/examples/create_reference.py
+++ b/examples/create_reference.py
@@ -19,7 +19,7 @@ privileges for creating References.
 
 import argparse
 import base64
-import json
+from pprint import pprint
 import vt
 
 
@@ -170,7 +170,7 @@ def main():
 
   client.close()
   if reference_obj:
-    print(json.dumps(reference_obj.to_dict(), indent=2))
+    print(pprint(reference_obj.to_dict()))
 
 
 if __name__ == "__main__":

--- a/examples/update_collection.py
+++ b/examples/update_collection.py
@@ -62,7 +62,7 @@ def main():
   collection_obj = update_collection(client, args.id, iocs)
 
   client.close()
-  print(pprint(collection_obj.to_dict()))
+  pprint(collection_obj.to_dict())
 
   print(f"Link:\n{generate_ui_link(collection_obj.id)}")
 

--- a/examples/update_collection.py
+++ b/examples/update_collection.py
@@ -15,7 +15,7 @@
 
 import argparse
 import io
-import json
+from pprint import pprint
 import vt
 
 
@@ -62,7 +62,7 @@ def main():
   collection_obj = update_collection(client, args.id, iocs)
 
   client.close()
-  print(json.dumps(collection_obj.to_dict(), indent=2))
+  print(pprint(collection_obj.to_dict()))
 
   print(f"Link:\n{generate_ui_link(collection_obj.id)}")
 


### PR DESCRIPTION
Some example files are failing because of json.dumps:
TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type WhistleBlowerDict is not JSON serializable

Using pprint, json.dumps is not needed 