### PR TITLE
Fix: Fix aiohttp version to be compatible with Python 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setuptools.setup(
     url="https://github.com/VirusTotal/vt-py",
     packages=["vt"],
     python_requires=">=3.7.0",
-    install_requires=["aiohttp"],
+    install_requires=["aiohttp==3.8.6"],
     setup_requires=["pytest-runner"],
     extras_require={"test": ["pytest", "pytest_httpserver", "pytest_asyncio"]},
     classifiers=[


### PR DESCRIPTION
aiohttp has dropped Python 3.7 y recent versions, so to not break clients using this library (as the Splunk integration) I'm fixing the last aiohttp version compatible with 3.7.