### PR TITLE
Pin aiohtp to 3.8.6 for python 3.7; use a newer version for python > 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,10 @@ setuptools.setup(
     url="https://github.com/VirusTotal/vt-py",
     packages=["vt"],
     python_requires=">=3.7.0",
-    install_requires=["aiohttp==3.8.6"],
+    install_requires=[
+        "aiohttp==3.8.6 ; python_version=='3.7'",
+        "aiohttp ; python_version>'3.7'"
+    ],
     setup_requires=["pytest-runner"],
     extras_require={"test": ["pytest", "pytest_httpserver", "pytest_asyncio"]},
     classifiers=[


### PR DESCRIPTION
The recently merged MR https://github.com/VirusTotal/vt-py/pull/184 broke Python 3.12 compatibility.

This patch fixes that while keeping aiohttp pinned to 3.8.6 for Python 3.7

Merging this would be highly appreciated as distros start rolling out Python 3.12