### PR TITLE
fix(client): Fix Runtime error when running non async apps

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pylint aiohttp pytest_httpserver pytest_asyncio
+          pip install pytest pylint aiohttp pytest_httpserver pytest_asyncio flask
       - name: Lint
         run: |
           pylint --rcfile pylintrc vt/ tests examples/

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,9 @@ setuptools.setup(
     python_requires=">=3.7.0",
     install_requires=["aiohttp"],
     setup_requires=["pytest-runner"],
-    extras_require={"test": ["pytest", "pytest_httpserver", "pytest_asyncio"]},
+    extras_require={
+        "test": ["pytest", "pytest_httpserver", "pytest_asyncio", "flask"]
+    },
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: Apache Software License",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -27,7 +27,7 @@ from vt import Object
 from tests import wsgi_app
 
 
-def new_client(httpserver, unused_apikey=''):
+def new_client(httpserver, unused_apikey=""):
   return Client(
       "dummy_api_key",
       host="http://" + httpserver.host + ":" + str(httpserver.port),
@@ -487,12 +487,12 @@ def test_user_headers(httpserver):
 
 def test_wsgi_app(httpserver, monkeypatch):
   app = wsgi_app.app
-  app.config.update({'TESTING': True})
+  app.config.update({"TESTING": True})
   client = app.test_client()
-  expected_response = {'data': {
-      'id': 'google.com',
-      'type': 'domain',
-      'attributes': {'foo': 'foo'},
+  expected_response = {"data": {
+      "id": "google.com",
+      "type": "domain",
+      "attributes": {"foo": "foo"},
   }}
 
 
@@ -501,8 +501,8 @@ def test_wsgi_app(httpserver, monkeypatch):
       headers={"X-Apikey": "dummy_api_key"}
   ).respond_with_json(expected_response)
   monkeypatch.setattr(
-      'tests.wsgi_app.vt.Client', functools.partial(new_client, httpserver)
+      "tests.wsgi_app.vt.Client", functools.partial(new_client, httpserver)
   )
-  response = client.get('/')
+  response = client.get("/")
   assert response.status_code == 200
   assert response.json == expected_response

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -15,6 +15,7 @@
 
 import datetime
 import io
+import functools
 import json
 import pickle
 
@@ -23,8 +24,10 @@ from vt import APIError
 from vt import Client
 from vt import Object
 
+from tests import wsgi_app
 
-def new_client(httpserver):
+
+def new_client(httpserver, unused_apikey=''):
   return Client(
       "dummy_api_key",
       host="http://" + httpserver.host + ":" + str(httpserver.port),
@@ -480,3 +483,26 @@ def test_user_headers(httpserver):
   assert "Accept-Encoding" in headers
   assert "User-Agent" in headers
   assert "foo" in headers
+
+
+def test_wsgi_app(httpserver, monkeypatch):
+  app = wsgi_app.app
+  app.config.update({'TESTING': True})
+  client = app.test_client()
+  expected_response = {'data': {
+      'id': 'google.com',
+      'type': 'domain',
+      'attributes': {'foo': 'foo'},
+  }}
+
+
+  httpserver.expect_request(
+      "/api/v3/domains/google.com", method="GET",
+      headers={"X-Apikey": "dummy_api_key"}
+  ).respond_with_json(expected_response)
+  monkeypatch.setattr(
+      'tests.wsgi_app.vt.Client', functools.partial(new_client, httpserver)
+  )
+  response = client.get('/')
+  assert response.status_code == 200
+  assert response.json == expected_response

--- a/tests/wsgi_app.py
+++ b/tests/wsgi_app.py
@@ -1,0 +1,12 @@
+import flask
+import os
+import vt
+
+app = flask.Flask(__name__)
+
+
+@app.get('/')
+def home():
+  with vt.Client(os.getenv('VT_APIKEY')) as c:
+    g = c.get('/domains/google.com')
+    return g.json()

--- a/tests/wsgi_app.py
+++ b/tests/wsgi_app.py
@@ -1,3 +1,5 @@
+"""Simulates a Flask app using vt-py to test non-async environments."""
+
 import flask
 import os
 import vt

--- a/vt/client.py
+++ b/vt/client.py
@@ -238,7 +238,17 @@ class Client:
     if connector is not None:
       self._connector = connector
     else:
-      self._connector = aiohttp.TCPConnector(ssl=self._verify_ssl)
+      # the TCPConnector class expects to be instantiated inside a event loop.
+      # If there is none, create one.
+      try:
+        event_loop = asyncio.get_event_loop()
+      except RuntimeError:
+        event_loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(event_loop)
+
+      self._connector = aiohttp.TCPConnector(
+          ssl=self._verify_ssl, loop=event_loop
+      )
 
   def _full_url(self, path:str, *args: typing.Any) -> str:
     try:


### PR DESCRIPTION
closes #183 

The VT Client expected to be called inside an asyncio coroutine and when it was not (for example, when running non-async wsgi apps) it raised a runtime error exception because there was no event loop. This PR fixes that.