### PR TITLE
fix: Create timezone-aware datetime for Objects

### DIFF
--- a/vt/object.py
+++ b/vt/object.py
@@ -160,7 +160,7 @@ class Object:
     value = super().__getattribute__(attr)
     for r in Object.DATE_ATTRIBUTES:
       if r.match(attr):
-        value = datetime.datetime.utcfromtimestamp(value)
+        value = datetime.datetime.fromtimestamp(value, datetime.UTC)
         break
     return value
 


### PR DESCRIPTION
Use `.fromtimestamp` instead of `.utcfromtimestamp` to create a timezone-aware datetime object.

Previously, the object was naive. `.utcfromtimestamp` is deprecated because naive datetime objects lead to ambiguity and problems.

By using a datetime-aware object, is is clearly signaled to the caller that the datetime is a UTC-timestamp, and it may easily be converted using `.astimezone`