### PR TITLE
Fix vt-feed `NotAvailableYet` error code

### DIFF
--- a/vt/feed.py
+++ b/vt/feed.py
@@ -106,7 +106,7 @@ class Feed:
       error = await self._client.get_error_async(response)
       if not error:
         break
-      if error.code == "NotAvailableYet":
+      if error.code == "NotAvailableYetError":
         await asyncio.sleep(60)
       else:
         raise error


### PR DESCRIPTION
As far as I can tell, VT introduced a compatibility breaking bug and changed the error code from `NotAvailableYet` to `NotAvailableYetError`.

This is not reflected in the [documentation](https://docs.virustotal.com/reference/errors) and breaks all scripts making use of VirusTotal feed products.

Example API response containing the new error:
```python
{'error': {'code': 'NotAvailableYetError', 'message': 'Package 202408231413 is not available until 2024-08-23 at 15:13 UTC because of privacy policy.'}}
```