### PR TITLE
feat: Add private scan support with code insight

### DIFF
--- a/examples/private_scan.py
+++ b/examples/private_scan.py
@@ -1,0 +1,98 @@
+"""
+Tool for scanning files privately using VirusTotal API.
+Supports code insight analysis and waiting for scan completion.
+"""
+
+import sys
+import asyncio
+import argparse
+from pathlib import Path
+import vt
+from rich.console import Console
+from rich.progress import Progress
+
+console = Console()
+
+async def scan_file_private(
+    api_key: str,
+    file_path: Path,
+    code_insight: bool = False,
+    wait: bool = False
+) -> None:
+    """
+    Scan a file privately on VirusTotal.
+    
+    Args:
+        api_key: VirusTotal API key
+        file_path: Path to file to scan
+        code_insight: Enable code analysis
+        wait: Wait for scan completion
+    """
+    async with vt.Client(api_key) as client:
+        try:
+            with Progress() as progress:
+                task = progress.add_task(
+                    "Scanning file...",
+                    total=None if wait else 1
+                )
+                
+                analysis = await client.scan_file_private_async(
+                    str(file_path),
+                    code_insight=code_insight,
+                    wait_for_completion=wait
+                )
+                
+                progress.update(task, advance=1)
+                
+                console.print("\n[green]Scan submitted successfully[/green]")
+                console.print(f"Analysis ID: {analysis.id}")
+                
+                if wait:
+                    console.print(f"\nScan Status: {analysis.status}")
+                    if hasattr(analysis, 'stats'):
+                        console.print("Detection Stats:")
+                        for k, v in analysis.stats.items():
+                            console.print(f"  {k}: {v}")
+                
+        except vt.error.APIError as e:
+            console.print(f"[red]API Error: {e}[/red]")
+        except Exception as e:
+            console.print(f"[red]Error: {e}[/red]")
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Scan file privately using VirusTotal API"
+    )
+    parser.add_argument("apikey", help="VirusTotal API key")
+    parser.add_argument("file_path", help="Path to file to scan")
+    parser.add_argument(
+        "--code-insight",
+        action="store_true",
+        help="Enable code analysis features"
+    )
+    parser.add_argument(
+        "--wait",
+        action="store_true",
+        help="Wait for scan completion"
+    )
+    
+    args = parser.parse_args()
+    file_path = Path(args.file_path)
+
+    if not file_path.exists():
+        console.print(f"[red]Error: File {file_path} not found[/red]")
+        sys.exit(1)
+        
+    if not file_path.is_file():
+        console.print(f"[red]Error: {file_path} is not a file[/red]")
+        sys.exit(1)
+
+    asyncio.run(scan_file_private(
+        args.apikey,
+        file_path,
+        args.code_insight,
+        args.wait
+    ))
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -507,3 +507,117 @@ def test_wsgi_app(httpserver, monkeypatch):
   response = client.get("/")
   assert response.status_code == 200
   assert response.json == expected_response
+
+def test_scan_file_private(httpserver):
+    """Test synchronous private file scanning."""
+    upload_url = f"http://{httpserver.host}:{httpserver.port}/upload"
+
+    # Mock upload URL request
+    httpserver.expect_request(
+        "/api/v3/files/upload_url",
+        method="GET"
+    ).respond_with_json({
+        "data": upload_url
+    })
+
+    # Mock file upload with proper data structure
+    httpserver.expect_request(
+        "/upload", 
+        method="POST"
+    ).respond_with_json({
+        "data": {
+            "id": "dummy_scan_id",
+            "type": "analysis",
+            "links": {
+                "self": "dummy_link"
+            },
+            "attributes": {
+                "status": "queued",
+                "private": True,
+                "code_insight": True
+            }
+        },
+        "meta": {
+            "test": True
+        }
+    })
+
+    with new_client(httpserver) as client:
+        with io.StringIO("test file content") as f:
+            analysis = client.scan_file_private(f, code_insight=True)
+
+        assert analysis.id == "dummy_scan_id"
+        assert analysis.type == "analysis"
+        assert getattr(analysis, "status") == "queued"
+        assert getattr(analysis, "private") is True
+        assert getattr(analysis, "code_insight") is True
+
+@pytest.mark.asyncio 
+async def test_scan_file_private_async(httpserver):
+    """Test asynchronous private file scanning."""
+    upload_url = f"http://{httpserver.host}:{httpserver.port}/upload"
+
+    # Mock upload URL request
+    httpserver.expect_request(
+        "/api/v3/files/upload_url",
+        method="GET"
+    ).respond_with_json({
+        "data": upload_url
+    })
+
+    # Mock file upload
+    httpserver.expect_request(
+        "/upload",
+        method="POST"
+    ).respond_with_json({
+        "data": {
+            "id": "dummy_scan_id",
+            "type": "analysis",
+            "links": {
+                "self": "dummy_link"
+            },
+            "attributes": {
+                "status": "queued",
+                "private": True,
+                "code_insight": True
+            }
+        }
+    })
+
+    # Mock analysis status check
+    httpserver.expect_request(
+        "/api/v3/analyses/dummy_scan_id",
+        method="GET"
+    ).respond_with_json({
+        "data": {
+            "id": "dummy_scan_id",
+            "type": "analysis",
+            "links": {
+                "self": "dummy_link"
+            },
+            "attributes": {
+                "status": "completed",
+                "private": True,
+                "code_insight": True,
+                "stats": {
+                    "malicious": 0,
+                    "suspicious": 0
+                }
+            }
+        }
+    })
+
+    async with new_client(httpserver) as client:
+        with io.StringIO("test file content") as f:
+            analysis = await client.scan_file_private_async(
+                f,
+                code_insight=True,
+                wait_for_completion=True
+            )
+
+        assert analysis.id == "dummy_scan_id"
+        assert analysis.type == "analysis"
+        assert getattr(analysis, "status") == "completed"
+        assert getattr(analysis, "private") is True
+        assert getattr(analysis, "code_insight") is True
+        assert hasattr(analysis, "stats")

--- a/vt/client.py
+++ b/vt/client.py
@@ -19,6 +19,8 @@ import functools
 import io
 import json
 import typing
+import os
+import aiofiles
 
 import aiohttp
 
@@ -973,3 +975,59 @@ class Client:
 
   async def wait_for_analysis_completion(self, analysis: Object) -> Object:
     return await self._wait_for_analysis_completion(analysis)
+
+  def scan_file_private(
+      self, 
+      file: typing.Union[typing.BinaryIO, str],
+      code_insight: bool = False,
+      wait_for_completion: bool = False
+  ) -> Object:
+      """Scan file privately with optional code insight analysis.
+      
+      Args:
+          file: File to scan (path string or file object)
+          code_insight: Enable code analysis features
+          wait_for_completion: Wait for completion
+          
+      Returns:
+          Object: Analysis object with scan results
+      """
+      return make_sync(
+          self.scan_file_private_async(file, code_insight, wait_for_completion)
+      )
+
+  async def scan_file_private_async(
+      self,
+      file: typing.Union[typing.BinaryIO, str],
+      code_insight: bool = False, 
+      wait_for_completion: bool = False
+  ) -> Object:
+      """Async version of scan_file_private"""
+      
+      # Handle string path
+      if isinstance(file, str):
+          async with aiofiles.open(file, 'rb') as f:
+              file_content = io.BytesIO(await f.read())
+              file_content.name = os.path.basename(file)
+              return await self.scan_file_private_async(
+                  file_content,
+                  code_insight=code_insight,
+                  wait_for_completion=wait_for_completion
+              )
+
+      # Create form data
+      form = aiohttp.FormData()
+      form.add_field('file', file)
+      form.add_field('private', '1')
+      form.add_field('code_insight', '1' if code_insight else '0')
+
+      # Get upload URL and submit file
+      upload_url = await self.get_data_async("/files/upload_url")
+      response = await self.post_async(upload_url, data=form)
+      
+      analysis = await self._response_to_object(response)
+
+      if wait_for_completion:
+          analysis = await self._wait_for_analysis_completion(analysis)
+      
+      return analysis


### PR DESCRIPTION
# Add private file scanning support with Code Insight
Fixes #182

## Changes
- Added `scan_file_private()` and `scan_file_private_async()` methods
- Implemented Code Insight support for private scans

### Implementation Details
- Private scanning via `private=1` parameter
- Code Insight via `code_insight` flag
- Support for both sync/async operations
- Progress tracking with rich console output
- Proper file handle management
- Enhanced error handling

### Testing
- All tests passing
- Manually tested with example script