### PR TITLE
chore: Migrate to trusted publishers

### DIFF
--- a/.github/workflows/publishing.yaml
+++ b/.github/workflows/publishing.yaml
@@ -5,8 +5,14 @@ on:
     types: [published]
 
 jobs:
-  deploy:
+  pypi-publish:
+    name: Upload release to PyPI
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/vt-py
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
@@ -19,8 +25,5 @@ jobs:
           pip install build
       - name: Build package
         run: python -m build
-      - name: Publish package
+      - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Migrate to trusted publishers using the steps described at https://docs.pypi.org/trusted-publishers/using-a-publisher/