### PR TITLE
refactor: convert UserDict (WhistleBlowerDict) into plain dict

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -13,6 +13,7 @@
 
 """Client tests."""
 
+import collections
 import datetime
 import io
 import functools
@@ -99,6 +100,9 @@ def test_object_to_dict():
           },
       }
   )
+
+  obj_dict = obj.to_dict()
+  assert not isinstance(obj_dict["attributes"]["attr3"], collections.UserDict)
 
   obj.set_data("data_key", {"some": "value"})
 

--- a/vt/client.py
+++ b/vt/client.py
@@ -15,7 +15,6 @@
 
 import asyncio
 import base64
-import functools
 import io
 import json
 import typing
@@ -28,7 +27,6 @@ from .error import APIError
 from .feed import Feed, FeedType
 from .iterator import Iterator
 from .object import Object
-from .object import UserDictJsonEncoder
 from .utils import make_sync
 from .version import __version__
 
@@ -281,7 +279,6 @@ class Client:
           headers=headers,
           trust_env=self._trust_env,
           timeout=aiohttp.ClientTimeout(total=self._timeout),
-          json_serialize=functools.partial(json.dumps, cls=UserDictJsonEncoder),
       )
     return self._session
 

--- a/vt/object.py
+++ b/vt/object.py
@@ -50,14 +50,16 @@ class WhistleBlowerDict(collections.UserDict):
     super().__delitem__(item)
 
 
-class UserDictJsonEncoder(json.JSONEncoder):
-  """Custom json encoder for UserDict objects."""
-
-  def default(self, o):
-    if isinstance(o, collections.UserDict):
-      return o.data
-    return super().default(o)
-
+def to_plain_dict(d: typing.Dict) -> typing.Dict:
+  plain = {}
+  for k, v in d.items():
+    if isinstance(v, collections.UserDict):
+      plain[k] = to_plain_dict(v.data)
+    elif isinstance(v, dict):
+      plain[k] = to_plain_dict(v)
+    else:
+      plain[k] = v
+  return plain
 
 class Object:
   """This class encapsulates any type of object in the VirusTotal API.
@@ -246,4 +248,4 @@ class Object:
     for key, val in self._modified_data.items():
       result[key] = val
 
-    return result
+    return to_plain_dict(result)


### PR DESCRIPTION
Implement #210. 

This is a bit opinionated PR but, from a user's point of view, I think it makes this library more usable. 