### PR TITLE
fix: AttributeError

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -76,7 +76,8 @@ def test_object_date_attrs():
   obj = Object("dummy_type")
   obj.foo_date = 0
 
-  assert obj.foo_date == datetime.datetime(1970, 1, 1, 0, 0, 0)
+  assert obj.foo_date == datetime.datetime(
+      1970, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
 
 
 def test_object_pickle():

--- a/vt/object.py
+++ b/vt/object.py
@@ -159,7 +159,7 @@ class Object:
     value = super().__getattribute__(attr)
     for r in Object.DATE_ATTRIBUTES:
       if r.match(attr):
-        value = datetime.datetime.fromtimestamp(value, datetime.UTC)
+        value = datetime.datetime.fromtimestamp(value, datetime.timezone.utc)
         break
     return value
 


### PR DESCRIPTION
`datetime.UTC` was added in python 3.11 so the tests from lower versions are not passing.