### PR TITLE
Fix private file scan

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -552,7 +552,7 @@ def private_scan_mocks(httpserver):
 
   # Add mock for analysis status endpoint
   httpserver.expect_request(
-      "/api/v3/analyses/dummy_scan_id", method="GET"
+      "/api/v3/private/analyses/dummy_scan_id", method="GET"
   ).respond_with_json(
       {
           "data": {

--- a/vt/client.py
+++ b/vt/client.py
@@ -937,16 +937,19 @@ class Client:
 
     return analysis
 
-  async def _wait_for_analysis_completion(self, analysis: Object) -> Object:
+  async def _wait_for_analysis_completion(self, analysis: Object, private_path: bool = False) -> Object:
     while True:
-      analysis = await self.get_object_async("/analyses/{}", analysis.id)
+      if private_path:
+        analysis = await self.get_object_async("/private/analyses/{}", analysis.id)
+      else:
+        analysis = await self.get_object_async("/analyses/{}", analysis.id)
       if analysis.status == "completed":
         break
       await asyncio.sleep(20)
     return analysis
 
-  async def wait_for_analysis_completion(self, analysis: Object) -> Object:
-    return await self._wait_for_analysis_completion(analysis)
+  async def wait_for_analysis_completion(self, analysis: Object, private_path: bool = False) -> Object:
+    return await self._wait_for_analysis_completion(analysis, private_path)
 
   def scan_file_private(
       self,
@@ -991,6 +994,6 @@ class Client:
     analysis = await self._response_to_object(response)
 
     if wait_for_completion:
-      analysis = await self._wait_for_analysis_completion(analysis)
+      analysis = await self._wait_for_analysis_completion(analysis, True)
 
     return analysis


### PR DESCRIPTION
When file/url scan is triggered, the current implementation always checks the current job stats via ```/analyses``` path in ```wait_for_anaysis_completion``` function

But when a private file/url scan is triggered, the same URI path is being used which will yield ```NotFoundError``` because the private file/url uses ```/private/analyses``` path instead.